### PR TITLE
[feat]: default opened collapse and empty message

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -57,6 +57,11 @@ body {
   flex-direction: column;
   gap: 8px;
 }
+.sider__collections_empty {
+  color: gray;
+  margin-top: 24px;
+  text-align: center;
+}
 .sider_collapse {
   border: none;
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,14 +18,6 @@ const Sidebar = () => {
     updateCollectionLabel,
   } = useCollectionContext();
 
-  // const collections = [
-  //   {
-  //     routes: [],
-  //     id: 'c4661d31-30b8-4dc6-92bd-2127d828b215',
-  //     label: 'collection-1',
-  //   },
-  // ];
-
   const onNewCollectionClick = () => {
     setSelectedId('');
     addCollection();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,6 +18,14 @@ const Sidebar = () => {
     updateCollectionLabel,
   } = useCollectionContext();
 
+  // const collections = [
+  //   {
+  //     routes: [],
+  //     id: 'c4661d31-30b8-4dc6-92bd-2127d828b215',
+  //     label: 'collection-1',
+  //   },
+  // ];
+
   const onNewCollectionClick = () => {
     setSelectedId('');
     addCollection();
@@ -70,12 +78,19 @@ const Sidebar = () => {
         </Button>
       </Row>
       <div className="sider__collections">
-        <Collapse
-          ghost
-          className="sider_collapse"
-          items={createCollectionAccordionsProps(collections)}
-          bordered={false}
-        />
+        {collections.length > 0 ? (
+          <Collapse
+            ghost
+            bordered={false}
+            defaultActiveKey={[collections[0].id]}
+            className="sider_collapse"
+            items={createCollectionAccordionsProps(collections)}
+          />
+        ) : (
+          <p className="sider__collections_empty">
+            You must first create or import a collection
+          </p>
+        )}
         <Modal
           title="Edit Collection"
           open={selectedCollection !== ''}


### PR DESCRIPTION
- The first collapse item is expanded initially
- If there is no collection, the empty message is rendered

![Screenshot 2025-01-16 at 11 05 48](https://github.com/user-attachments/assets/8f8325b2-f5fb-4ea4-ae9d-c84df11204b6)
